### PR TITLE
fix build script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "dev": "node ./dev.js",
-    "build": "./node_modules/.bin/babel src --out-dir dist --copy-files --extensions \".ts\"",
+    "build": "babel src --out-dir dist --copy-files --extensions \".ts\"",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "prepublishOnly": "npm run build & npm run test"


### PR DESCRIPTION
specifying path to babel script with / breaks compilation on Windows

npm/pnpm/yarn will use the locally installed version of babel in
node_modules folder