### PR TITLE
Add progress bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "dev": "node ./dev.js",
-    "build": "./node_modules/.bin/babel src --out-dir dist --copy-files --extensions \".ts\"",
+    "build": "babel src --out-dir dist --copy-files --extensions \".ts\"",
     "test": "jest --forceExit",
     "test:coverage": "jest --coverage",
     "prepublishOnly": "npm run build & npm run test --forceExit"
@@ -36,7 +36,9 @@
     "@types/jest": "^26.0.24",
     "@types/node": "^15.14.9",
     "babel-jest": "^26.6.3",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "cli-progress": "^3.12.0",
+    "@types/cli-progress": "^3.11.0"
   },
   "repository": {
     "type": "git",

--- a/src/obfuscator.ts
+++ b/src/obfuscator.ts
@@ -49,7 +49,7 @@ export default class Obfuscator extends EventEmitter {
 
   totalPossibleTransforms: number;
 
-  progress_bar: any;
+  progress_bar: SingleBar | undefined;
 
 
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -21,6 +21,13 @@ export interface ObfuscateOptions {
   preset?: "high" | "medium" | "low" | false;
 
   /**
+   * ### `progress`
+   *
+   * Whether to display a graphical progress bar in the STDOUT. (`true/false`)
+   */
+  progress?: true | false;
+
+  /**
    * ### `target`
    *
    * The execution context for your output. _Required_.
@@ -669,6 +676,7 @@ export interface ObfuscateOptions {
 
 const validProperties = new Set([
   "preset",
+  "progress",
   "target",
   "indent",
   "compact",


### PR DESCRIPTION
Add 'progress' to Options, which displays a visual progress bar of the obfuscation process in STDOUT
![image](https://github.com/MichaelXF/js-confuser/assets/54221024/6fe55c74-425b-4fd5-9ffd-b73c63bf2262)

Example:
```js
JsConfuser.obfuscate(contents, {
    target: "browser",
    progress: true,
    preset: "high"
})
```
