### PR TITLE
fix `__getGlobal` in BufferToStringTemplate

### DIFF
--- a/src/templates/bufferToString.ts
+++ b/src/templates/bufferToString.ts
@@ -2,9 +2,9 @@ import Template from "./template";
 
 export const BufferToStringTemplate = Template(`
   function __getGlobal(){
-    try { return globalThis } catch {}
-    try { return window } catch {}
-    try { return global } catch {}
+    if(typeof globalThis !== "undefined") return globalThis;
+    if(typeof window !== "undefined") return window;
+    if(typeof global !== "undefined") return global;
     try { return new Function("return this")() } catch {}
     return this;
   }

--- a/src/templates/bufferToString.ts
+++ b/src/templates/bufferToString.ts
@@ -2,15 +2,11 @@ import Template from "./template";
 
 export const BufferToStringTemplate = Template(`
   function __getGlobal(){
-    try {
-      return global||window|| ( new Function("return this") )();
-    } catch ( e ) {
-      try {
-        return this;
-      } catch ( e ) {
-        return {};
-      }
-    }
+		try { return globalThis } catch {}
+		try { return window } catch {}
+		try { return global } catch {}
+		try { return new Function("return this")() } catch {}
+		return this;
   }
 
   var __globalObject = __getGlobal() || {};

--- a/src/templates/bufferToString.ts
+++ b/src/templates/bufferToString.ts
@@ -2,11 +2,11 @@ import Template from "./template";
 
 export const BufferToStringTemplate = Template(`
   function __getGlobal(){
-		try { return globalThis } catch {}
-		try { return window } catch {}
-		try { return global } catch {}
-		try { return new Function("return this")() } catch {}
-		return this;
+    try { return globalThis } catch {}
+    try { return window } catch {}
+    try { return global } catch {}
+    try { return new Function("return this")() } catch {}
+    return this;
   }
 
   var __globalObject = __getGlobal() || {};


### PR DESCRIPTION
The current implementation does not work as expected.
If `global` is not known, it immediately throws a ReferenceError and does not even try `window` or `new Function("return this")()`