### PR TITLE
TypeError: Cannot read properties of undefined (reading 'referencePaths')

### DIFF
--- a/src/transforms/preparation.ts
+++ b/src/transforms/preparation.ts
@@ -182,6 +182,8 @@ export default ({ Plugin }: PluginArg): PluginObject => {
           var predictable = true;
           var maxArgLength = 0;
 
+          if (!binding) return;
+
           for (var referencePath of binding.referencePaths) {
             if (!referencePath.parentPath.isCallExpression()) {
               predictable = false;


### PR DESCRIPTION
When obfuscating with a nodejs polyfill for the browser, I'd sometimes get
```
TypeError: Cannot read properties of undefined (reading 'referencePaths')
    at exit (<redacted>/node_modules/js-confuser/dist/transforms/preparation.js:154:62)
```
With this PR I propose a fix to this error, however I'm not too sure what I'm doing so feel free to close this issue if my contribution is not of any value