### PR TITLE
Fix member expression targets being incorrectly flagged as modified identifiers

### DIFF
--- a/src/utils/ast-utils.ts
+++ b/src/utils/ast-utils.ts
@@ -536,19 +536,16 @@ export function isStrictMode(path: NodePath) {
  * @param identifierPath
  */
 export function isModifiedIdentifier(identifierPath: NodePath<t.Identifier>) {
-  var isModification = false;
   if (identifierPath.parentPath.isUpdateExpression()) {
-    isModification = true;
-  }
-  if (
-    identifierPath.find(
-      (p) => p.key === "left" && p.parentPath?.isAssignmentExpression()
-    )
-  ) {
-    isModification = true;
+    return true;
   }
 
-  return isModification;
+  return !!identifierPath.find(
+    (p) =>
+      p.key === "left" &&
+      p.parentPath?.isAssignmentExpression() &&
+      !p.isMemberExpression()
+  );
 }
 
 export function replaceDefiningIdentifierToMemberExpression(

--- a/test/transforms/flatten.test.ts
+++ b/test/transforms/flatten.test.ts
@@ -1,3 +1,5 @@
+import { parse } from "@babel/parser";
+import traverse from "@babel/traverse";
 import JsConfuser from "../../src/index";
 
 test("Variant #1: Function Declaration", async () => {
@@ -771,4 +773,29 @@ test("Variant #26: Var declaration in nested block statement", async () => {
   var TEST_OUTPUT;
   eval(code);
   expect(TEST_OUTPUT).toStrictEqual("Correct Value");
+});
+
+test("Variant #27: Mutating a property on a constant object should not generate a setter", async () => {
+  var { code } = await JsConfuser.obfuscate(
+    `
+    const myObject = {};
+
+    (function () {
+      myObject.myProperty = 1;
+    })()
+
+    TEST_OUTPUT = myObject.myProperty;
+    `,
+    { target: "node", flatten: true }
+  );
+
+  traverse(parse(code), {
+    ObjectMethod(path) {
+      expect(path.node.kind).not.toBe("set");
+    },
+  });
+
+  var TEST_OUTPUT;
+  eval(code);
+  expect(TEST_OUTPUT).toStrictEqual(1);
 });


### PR DESCRIPTION
Mutating a property on an object (e.g. obj.prop = 1) was incorrectly generating a setter for the object itself. Since the object variable is never reassigned, this produces an invalid setter for const variables, which causes downstream build tools to error on the generated code.

Minimal reproduction of the issue:

```js
import { obfuscate } from 'js-confuser'

const { code: output } = await obfuscate(
  `const foo = {}
    ;(function () {
      foo.bar = 0
    })()`,
  { target: 'browser', flatten: true }
)

console.log(output)
```

Before this commit, a setter is being generated attempting to reassign constant `foo`, which is invalid JS.